### PR TITLE
Updated check on problemWords property

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@
 		};
 		
 		// Return if we've hit one of those...
-		if (problemWords[word]) return problemWords[word];
+		if (problemWords.hasOwnProperty(word)) return problemWords[word];
 		
 		// These syllables would be counted as two but should be one
 		var subSyllables = [


### PR DESCRIPTION
We end up with NaN values when the current word is a non-direct property of the problemWords object.

Error:
problemWords["constructor"] => function() { ... }

Solution:
problemWords.hasOwnProperty("constructor") => false
