### PR TITLE
fix word count

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,8 @@
 	
 	TextStatistics.prototype.wordCount = function(text) {
 		text = text ? cleanText(text) : this.text;
-		return text.split(/[^a-z0-9]+/i).length || 1;
+		matches = text.match(/[\d\w]+/ig);
+    		return matches ? matches.length : 0;
 	};
 	
 	TextStatistics.prototype.averageWordsPerSentence = function(text) {


### PR DESCRIPTION
Fixes incorrect word count.

The current implementation adds a period to the end of any text, which adds an extra word count to any phrase.  Taking an example from https://github.com/cgiffard/TextStatistics.js/issues/4 for instance:
```
var stats = textstatistics("monkey goes yay");
stats.wordCount();
4
```